### PR TITLE
Replace Multitasking

### DIFF
--- a/src/events.py
+++ b/src/events.py
@@ -300,8 +300,8 @@ def open_door_using_entrance_id(entrance_id):
 # Events Management: Output actions timer for GENOUT_1/2/3
 
 
-def open_GEN_OUT(GEN_OUT_PIN, timer, GenNo):
-    relay.open_GEN_OUT(GEN_OUT_PIN, timer, GenNo)
+def open_GEN_OUT(GEN_OUT_NAME, timer, GenNo):
+    relay.open_GEN_OUT(GEN_OUT_NAME, timer, GenNo)
 
 # keep track of wiegand values and pins
 # check if person allowed to enter

--- a/src/program.py
+++ b/src/program.py
@@ -118,31 +118,6 @@ def check_events_for(entrance):
     events.time.sleep(0.1)
 
 
-# E1_is_active/E2_is_active
-def check_entrance_E1():
-    if not events.E1_is_active:
-        events.relay.unlock_entrance_one()
-    else:
-        events.relay.lock_entrance_one()
-        if events.verify_datetime(events.E1_entrance_schedule):
-            events.relay.unlock_entrance_one()
-        else:
-            events.relay.lock_entrance_one()
-
-# E1_is_active/E2_is_active
-
-
-def check_entrance_E2():
-    if not events.E2_is_active:
-        events.relay.unlock_entrance_two()
-    else:
-        events.relay.lock_entrance_two()
-        if events.verify_datetime(events.E2_entrance_schedule):
-            events.relay.unlock_entrance_two()
-        else:
-            events.relay.lock_entrance_two()
-
-
 def check_events_timer():
     # print("check_events_timer starting")
     while True:

--- a/src/relay.py
+++ b/src/relay.py
@@ -389,64 +389,64 @@ def open_GEN_OUT(GEN_OUT_PIN=None, timer=1000, GenNo=1):
 
 
 
-@multitasking.task
-def unlock_entrance_one():
+# @multitasking.task
+# def unlock_entrance_one():
 
-    setGpioMode()
-    setupRelayPin(Relay_1)
+#     setGpioMode()
+#     setupRelayPin(Relay_1)
 
-    # print(" EM 1 unlocked at " + str(datetime.now()))
-    try:
-        activateRelay(Relay_1, 'High')
-    except RuntimeError:
-        print("Entrance is still opened")
+#     # print(" EM 1 unlocked at " + str(datetime.now()))
+#     try:
+#         activateRelay(Relay_1, 'High')
+#     except RuntimeError:
+#         print("Entrance is still opened")
 
-    return
-
-
-@multitasking.task
-def lock_entrance_one():
-
-    setGpioMode()
-    setupRelayPin(Relay_1)
-
-    # print(" EM 1 locked at " + str(datetime.now()))
-    try:
-        deActivateRelay(Relay_1, 'High')
-    except RuntimeError:
-        print("Entrance is still opened")
-
-    return
+#     return
 
 
-@multitasking.task
-def unlock_entrance_two():
+# @multitasking.task
+# def lock_entrance_one():
 
-    setGpioMode()
-    setupRelayPin(Relay_2)
+#     setGpioMode()
+#     setupRelayPin(Relay_1)
 
-    # print(" EM 2 unlocked at " + str(datetime.now()))
-    try:
-        activateRelay(Relay_2, 'High')
-    except RuntimeError:
-        print("Entrance is still opened")
+#     # print(" EM 1 locked at " + str(datetime.now()))
+#     try:
+#         deActivateRelay(Relay_1, 'High')
+#     except RuntimeError:
+#         print("Entrance is still opened")
 
-    return
+#     return
 
 
-@multitasking.task
-def lock_entrance_two():
+# @multitasking.task
+# def unlock_entrance_two():
 
-    setGpioMode()
-    setupRelayPin(Relay_2)
+#     setGpioMode()
+#     setupRelayPin(Relay_2)
 
-    # print(" EM 2 locked at " + str(datetime.now()))
-    try:
-        deActivateRelay(Relay_2, 'High')
-    except RuntimeError:
-        print("Entrance is still opened")
+#     # print(" EM 2 unlocked at " + str(datetime.now()))
+#     try:
+#         activateRelay(Relay_2, 'High')
+#     except RuntimeError:
+#         print("Entrance is still opened")
 
-    return
+#     return
+
+
+# @multitasking.task
+# def lock_entrance_two():
+
+#     setGpioMode()
+#     setupRelayPin(Relay_2)
+
+#     # print(" EM 2 locked at " + str(datetime.now()))
+#     try:
+#         deActivateRelay(Relay_2, 'High')
+#     except RuntimeError:
+#         print("Entrance is still opened")
+
+#     return
 
 
 def main():

--- a/src/relay.py
+++ b/src/relay.py
@@ -354,7 +354,6 @@ def lock_unlock_entrance_two(thirdPartyOption=None, unlock=False):
     return
 
 
-@multitasking.task
 def open_GEN_OUT(GEN_OUT_PIN=None, timer=1000, GenNo=1):
     # # print("open_GEN_OUT activated")
     # doesnt get run on second scan
@@ -378,11 +377,11 @@ def open_GEN_OUT(GEN_OUT_PIN=None, timer=1000, GenNo=1):
 
     # # print(f" {GEN_OUT_PIN}  unlocked")
     try:
-        toggleRelayGen(relayPin=outputPin, activateLevel='High',
-                       activateMilliSeconds=timer, GenNo=GenNo
-                       )
+        # toggleRelayGen(relayPin=outputPin, activateLevel='High',
+        #                activateMilliSeconds=timer, GenNo=GenNo
+        #                )
+        thread_pool_executor.submit(toggleRelayGen, outputPin, 'High', timer, GenNo)
         # print(f"finish open_GEN_OUT {outputPin}")
-        cleanupGpio()
     except RuntimeError:
         print(f" {GEN_OUT_PIN} still opened")
     return

--- a/src/relay.py
+++ b/src/relay.py
@@ -388,67 +388,6 @@ def open_GEN_OUT(GEN_OUT_PIN=None, timer=1000, GenNo=1):
     return
 
 
-
-# @multitasking.task
-# def unlock_entrance_one():
-
-#     setGpioMode()
-#     setupRelayPin(Relay_1)
-
-#     # print(" EM 1 unlocked at " + str(datetime.now()))
-#     try:
-#         activateRelay(Relay_1, 'High')
-#     except RuntimeError:
-#         print("Entrance is still opened")
-
-#     return
-
-
-# @multitasking.task
-# def lock_entrance_one():
-
-#     setGpioMode()
-#     setupRelayPin(Relay_1)
-
-#     # print(" EM 1 locked at " + str(datetime.now()))
-#     try:
-#         deActivateRelay(Relay_1, 'High')
-#     except RuntimeError:
-#         print("Entrance is still opened")
-
-#     return
-
-
-# @multitasking.task
-# def unlock_entrance_two():
-
-#     setGpioMode()
-#     setupRelayPin(Relay_2)
-
-#     # print(" EM 2 unlocked at " + str(datetime.now()))
-#     try:
-#         activateRelay(Relay_2, 'High')
-#     except RuntimeError:
-#         print("Entrance is still opened")
-
-#     return
-
-
-# @multitasking.task
-# def lock_entrance_two():
-
-#     setGpioMode()
-#     setupRelayPin(Relay_2)
-
-#     # print(" EM 2 locked at " + str(datetime.now()))
-#     try:
-#         deActivateRelay(Relay_2, 'High')
-#     except RuntimeError:
-#         print("Entrance is still opened")
-
-#     return
-
-
 def main():
     trigger_relay_one()
     trigger_relay_two()

--- a/src/relay.py
+++ b/src/relay.py
@@ -3,7 +3,6 @@ import time
 import RPi.GPIO as GPIO
 from time import sleep
 from datetime import datetime
-import multitasking
 import json
 import os
 from lock import config_lock

--- a/src/relay.py
+++ b/src/relay.py
@@ -372,14 +372,10 @@ def open_GEN_OUT(GEN_OUT_PIN=None, timer=1000, GenNo=1):
         outputPin = GEN_OUT_3
         # # print(GEN_OUT_PIN,outputPin)
 
-    setGpioMode()
-    setupRelayPin(outputPin)
-
     # # print(f" {GEN_OUT_PIN}  unlocked")
     try:
-        # toggleRelayGen(relayPin=outputPin, activateLevel='High',
-        #                activateMilliSeconds=timer, GenNo=GenNo
-        #                )
+        setGpioMode()
+        setupRelayPin(outputPin)
         thread_pool_executor.submit(toggleRelayGen, outputPin, 'High', timer, GenNo)
         # print(f"finish open_GEN_OUT {outputPin}")
     except RuntimeError:

--- a/src/relay.py
+++ b/src/relay.py
@@ -354,21 +354,21 @@ def lock_unlock_entrance_two(thirdPartyOption=None, unlock=False):
     return
 
 
-def open_GEN_OUT(GEN_OUT_PIN=None, timer=1000, GenNo=1):
+def open_GEN_OUT(GEN_OUT_NAME=None, timer=1000, GenNo=1):
     # # print("open_GEN_OUT activated")
     # doesnt get run on second scan
 
     outputPin = None
 
-    if GEN_OUT_PIN == "GEN_OUT_1":
+    if GEN_OUT_NAME == "GEN_OUT_1":
         outputPin = GEN_OUT_1
         # # print(GEN_OUT_PIN,outputPin)
 
-    if GEN_OUT_PIN == "GEN_OUT_2":
+    if GEN_OUT_NAME == "GEN_OUT_2":
         outputPin = GEN_OUT_2
         # # print(GEN_OUT_PIN,outputPin)
 
-    if GEN_OUT_PIN == "GEN_OUT_3":
+    if GEN_OUT_NAME == "GEN_OUT_3":
         outputPin = GEN_OUT_3
         # # print(GEN_OUT_PIN,outputPin)
 
@@ -379,7 +379,7 @@ def open_GEN_OUT(GEN_OUT_PIN=None, timer=1000, GenNo=1):
         thread_pool_executor.submit(toggleRelayGen, outputPin, 'High', timer, GenNo)
         # print(f"finish open_GEN_OUT {outputPin}")
     except RuntimeError:
-        print(f" {GEN_OUT_PIN} still opened")
+        print(f" {GEN_OUT_NAME} still opened")
     return
 
 


### PR DESCRIPTION
The remaining multitasking functions in the codebase were:
`relay.open_GEN_OUT()`
`relay.unlock_entrance_one()`
`relay.lock_entrance_one()`
`relay.unlock_entrance_two()`
`relay.lock_entrance_two()`

Of these, all the unlock/lock functions were used by unused functions within the codebase (`program.check_entrance_E1()` and `program.check_entrance_E2()` aren't being used at all), so I deleted them along with the unused functions.

For `relay.open_GEN_OUT()`, I renamed the variable GEN_OUT_PIN to GEN_OUT_NAME to better reflect its actual type, and changed the multitasking to use the ThreadPoolExecutor.