### PR TITLE
Bugfix for dependency on network during boot up causing empty config file

### DIFF
--- a/src/GPIOconfig.py
+++ b/src/GPIOconfig.py
@@ -1,3 +1,5 @@
+print("GPIOconfig before imports")
+
 import threading
 import time
 import pigpio 
@@ -8,6 +10,8 @@ import gc
 from lock import config_lock
 from executor import thread_pool_executor
 
+print("GPIOconfig after imports")
+
 path = os.path.dirname(os.path.abspath(__file__))
 
 
@@ -17,6 +21,8 @@ path = os.path.dirname(os.path.abspath(__file__))
    3. includes function to detect events 
    3. includes class Timer
 '''
+
+print("GPIOconfig.py starting")
 
 config = None
 
@@ -59,6 +65,8 @@ Gen_In_3=None
 Gen_Out_3=None
 
 def update_config():
+   print("GPIOconfig.py in update_config")
+
    '''call program.update_config() after calling this'''
    global config, GPIOpins, Fire, Relay_1, Relay_2, E1_IN_D0, E1_IN_D1, E1_IN_Buzz, \
       E1_IN_Led, E1_OUT_D0, E1_OUT_D1, E1_OUT_Buzz, E1_OUT_Led, E1_Mag, E1_Button, \
@@ -152,6 +160,8 @@ def update_config():
 
    except:
       pass
+
+   print("GPIOconfig.py finish update_config")
 
 update_config() # initialise
 

--- a/src/GPIOconfig.py
+++ b/src/GPIOconfig.py
@@ -1,5 +1,3 @@
-print("GPIOconfig before imports")
-
 import threading
 import time
 import pigpio 
@@ -10,8 +8,6 @@ import gc
 from lock import config_lock
 from executor import thread_pool_executor
 
-print("GPIOconfig after imports")
-
 path = os.path.dirname(os.path.abspath(__file__))
 
 
@@ -21,8 +17,6 @@ path = os.path.dirname(os.path.abspath(__file__))
    3. includes function to detect events 
    3. includes class Timer
 '''
-
-print("GPIOconfig.py starting")
 
 config = None
 
@@ -65,8 +59,6 @@ Gen_In_3=None
 Gen_Out_3=None
 
 def update_config():
-   print("GPIOconfig.py in update_config")
-
    '''call program.update_config() after calling this'''
    global config, GPIOpins, Fire, Relay_1, Relay_2, E1_IN_D0, E1_IN_D1, E1_IN_Buzz, \
       E1_IN_Led, E1_OUT_D0, E1_OUT_D1, E1_OUT_Buzz, E1_OUT_Led, E1_Mag, E1_Button, \
@@ -160,8 +152,6 @@ def update_config():
 
    except:
       pass
-
-   print("GPIOconfig.py finish update_config")
 
 update_config() # initialise
 

--- a/src/api.py
+++ b/src/api.py
@@ -1,3 +1,5 @@
+print("api.py before imports")
+
 import gc
 
 import flask
@@ -22,6 +24,8 @@ import threading
 import time
 
 from executor import thread_pool_executor
+
+print("api.py after imports")
 
 print("Start api.py")
  
@@ -289,7 +293,7 @@ def display_top(snapshot, key_type='traceback', limit=10):
 
 def log_memory_usage_every_hour():
     print("api.py in log_memory_usage_every_hour")
-    
+
     tracemalloc.start(25)  # Adjust stack depth as needed
     try:
         while True:  # Modify or remove loop as per your use case

--- a/src/api.py
+++ b/src/api.py
@@ -1,5 +1,3 @@
-print("api.py before imports")
-
 import gc
 
 import flask
@@ -24,10 +22,6 @@ import threading
 import time
 
 from executor import thread_pool_executor
-
-print("api.py after imports")
-
-print("Start api.py")
  
 app = flask.Flask(__name__)
 app.config["DEBUG"] = False
@@ -35,8 +29,6 @@ path = os.path.dirname(os.path.abspath(__file__))
 
 @app.route('/api/status', methods=['GET'])
 def get_status():
-    print("api.py in get_status")
-
     '''returns healthcheck info
     
     Returns: (response)
@@ -77,14 +69,10 @@ def get_status():
 
 @app.route('/api/unlock/entrance/<entrance_id>', methods=['GET'])
 def unlock_entrance_unicon(entrance_id):
-    print("api.py in unlock_entrance_unicon")
-
     events.open_door_using_entrance_id(int(entrance_id))
     return flask.Response({},status=200)
 
 def update_config():
-    print("api.py in update_config")
-
     '''helper method to update config'''
     events.update_config()
     eventsMod.update_config()
@@ -95,8 +83,6 @@ def update_config():
 
 @app.route('/api/config', methods=['POST'])
 def post_config():
-    print("api.py in post_config")
-
     '''changes config.json and post changes to etlas, 
     aborts if controllerSerialNo is different
     
@@ -129,8 +115,6 @@ def post_config():
 
 @app.route('/api/reset', methods=['POST'])
 def post_reset():
-    print("api.py in post_reset")
-
     '''Resets the controller. Resets ip to 192.168.1.67. then posts new config to etlas
     
     Returns (response):
@@ -142,23 +126,17 @@ def post_reset():
 
 @app.route('/api/reboot', methods=['POST'])
 def post_reboot():
-    print("api.py in post_reboot")
-
     '''reboots the controller'''
     os.system('sudo reboot')
 
 @app.route('/api/shutdown', methods=['POST'])
 def post_shutdown():
-    print("api.py in post_shutdown")
-
     '''shutdowns the controller'''
     changeStatic.change_dhcp()
     os.system('sudo halt')
 
 @app.route('/api/entrance-name', methods=['POST'])
 def post_entrance_name():
-    print("api.py in post_entrance_name")
-
     '''changes config.json
 
     Args (request):
@@ -195,22 +173,16 @@ def post_entrance_name():
     
 @app.route('/api/healthcheck')
 def get_check():
-    print("api.py in get_check")
-
     healthcheck.main(True)
     return flask.Response({}, 204)
 
 def update_credOccur():
-    print("api.py in update_credOccur")
-
     '''helper method to update credOccur'''
     events.update_credOccur()
     events.check_entrance_status()
 
 @app.route('/api/credOccur', methods=['POST'])
 def post_credOccur():
-    print("api.py in post_credOccur")
-
     '''changes credOccur.json
 
     Check https://iss-sec.atlassian.net/wiki/spaces/ISSSEC/pages/194805765/JSON+File+for+credOccur+Schedules+and+AccessGroups
@@ -227,15 +199,11 @@ def post_credOccur():
     return flask.Response({}, 200)
 
 def update_eventActionTriggers():
-    print("api.py in update_eventActionTriggers")
-
     '''helper function to store all script updates'''
     eventActionTriggers.update_event_action_triggers()
 
 @app.route('/api/eventActionTriggers',methods=['POST'])
 def post_eventActionTriggers():
-    print("api.py in post_eventActionTriggers")
-
     '''changes eventActionTriggers
     
     Check for format
@@ -252,21 +220,15 @@ def post_eventActionTriggers():
 
 @app.route('/api/piProperty', methods=['GET'])
 def get_piProperty():
-    print("api.py in get_piProperty")
-
     data = piProperty.get_system_stats()
     return flask.Response(json.dumps(data), headers={ 'Content-type': 'application/json' }, status=200)
 
 @app.route('/api/exit', methods=['GET'])
 def exit_button_api():
-    print("api.py in exit_button_api")
-
     data = events.button_detects_change(5, "", "")
     return flask.Response('', status=204)
 
 def display_top(snapshot, key_type='traceback', limit=10):
-    print("api.py in display_top")
-
     snapshot = snapshot.filter_traces((
         tracemalloc.Filter(False, "<frozen importlib._bootstrap>"),
         tracemalloc.Filter(False, "<unknown>"),
@@ -292,8 +254,6 @@ def display_top(snapshot, key_type='traceback', limit=10):
         # print("Total allocated size: %.1f KiB" % (total / 1024), file=f)
 
 def log_memory_usage_every_hour():
-    print("api.py in log_memory_usage_every_hour")
-
     tracemalloc.start(25)  # Adjust stack depth as needed
     try:
         while True:  # Modify or remove loop as per your use case
@@ -306,6 +266,4 @@ def log_memory_usage_every_hour():
 
 thread_pool_executor.submit(log_memory_usage_every_hour)
 
-print("api.py before app.run")
 app.run(host='0.0.0.0',port=5000,debug = False)
-print("api.py after app.run")

--- a/src/api.py
+++ b/src/api.py
@@ -23,12 +23,16 @@ import time
 
 from executor import thread_pool_executor
 
+print("Start api.py")
+ 
 app = flask.Flask(__name__)
 app.config["DEBUG"] = False
 path = os.path.dirname(os.path.abspath(__file__))
 
 @app.route('/api/status', methods=['GET'])
 def get_status():
+    print("api.py in get_status")
+
     '''returns healthcheck info
     
     Returns: (response)
@@ -69,10 +73,14 @@ def get_status():
 
 @app.route('/api/unlock/entrance/<entrance_id>', methods=['GET'])
 def unlock_entrance_unicon(entrance_id):
+    print("api.py in unlock_entrance_unicon")
+
     events.open_door_using_entrance_id(int(entrance_id))
     return flask.Response({},status=200)
 
 def update_config():
+    print("api.py in update_config")
+
     '''helper method to update config'''
     events.update_config()
     eventsMod.update_config()
@@ -83,6 +91,8 @@ def update_config():
 
 @app.route('/api/config', methods=['POST'])
 def post_config():
+    print("api.py in post_config")
+
     '''changes config.json and post changes to etlas, 
     aborts if controllerSerialNo is different
     
@@ -115,6 +125,8 @@ def post_config():
 
 @app.route('/api/reset', methods=['POST'])
 def post_reset():
+    print("api.py in post_reset")
+
     '''Resets the controller. Resets ip to 192.168.1.67. then posts new config to etlas
     
     Returns (response):
@@ -126,17 +138,23 @@ def post_reset():
 
 @app.route('/api/reboot', methods=['POST'])
 def post_reboot():
+    print("api.py in post_reboot")
+
     '''reboots the controller'''
     os.system('sudo reboot')
 
 @app.route('/api/shutdown', methods=['POST'])
 def post_shutdown():
+    print("api.py in post_shutdown")
+
     '''shutdowns the controller'''
     changeStatic.change_dhcp()
     os.system('sudo halt')
 
 @app.route('/api/entrance-name', methods=['POST'])
 def post_entrance_name():
+    print("api.py in post_entrance_name")
+
     '''changes config.json
 
     Args (request):
@@ -173,16 +191,22 @@ def post_entrance_name():
     
 @app.route('/api/healthcheck')
 def get_check():
+    print("api.py in get_check")
+
     healthcheck.main(True)
     return flask.Response({}, 204)
 
 def update_credOccur():
+    print("api.py in update_credOccur")
+
     '''helper method to update credOccur'''
     events.update_credOccur()
     events.check_entrance_status()
 
 @app.route('/api/credOccur', methods=['POST'])
 def post_credOccur():
+    print("api.py in post_credOccur")
+
     '''changes credOccur.json
 
     Check https://iss-sec.atlassian.net/wiki/spaces/ISSSEC/pages/194805765/JSON+File+for+credOccur+Schedules+and+AccessGroups
@@ -199,11 +223,15 @@ def post_credOccur():
     return flask.Response({}, 200)
 
 def update_eventActionTriggers():
+    print("api.py in update_eventActionTriggers")
+
     '''helper function to store all script updates'''
     eventActionTriggers.update_event_action_triggers()
 
 @app.route('/api/eventActionTriggers',methods=['POST'])
 def post_eventActionTriggers():
+    print("api.py in post_eventActionTriggers")
+
     '''changes eventActionTriggers
     
     Check for format
@@ -220,15 +248,21 @@ def post_eventActionTriggers():
 
 @app.route('/api/piProperty', methods=['GET'])
 def get_piProperty():
+    print("api.py in get_piProperty")
+
     data = piProperty.get_system_stats()
     return flask.Response(json.dumps(data), headers={ 'Content-type': 'application/json' }, status=200)
 
 @app.route('/api/exit', methods=['GET'])
 def exit_button_api():
+    print("api.py in exit_button_api")
+
     data = events.button_detects_change(5, "", "")
     return flask.Response('', status=204)
 
 def display_top(snapshot, key_type='traceback', limit=10):
+    print("api.py in display_top")
+
     snapshot = snapshot.filter_traces((
         tracemalloc.Filter(False, "<frozen importlib._bootstrap>"),
         tracemalloc.Filter(False, "<unknown>"),
@@ -254,6 +288,8 @@ def display_top(snapshot, key_type='traceback', limit=10):
         # print("Total allocated size: %.1f KiB" % (total / 1024), file=f)
 
 def log_memory_usage_every_hour():
+    print("api.py in log_memory_usage_every_hour")
+    
     tracemalloc.start(25)  # Adjust stack depth as needed
     try:
         while True:  # Modify or remove loop as per your use case
@@ -266,4 +302,6 @@ def log_memory_usage_every_hour():
 
 thread_pool_executor.submit(log_memory_usage_every_hour)
 
+print("api.py before app.run")
 app.run(host='0.0.0.0',port=5000,debug = False)
+print("api.py after app.run")

--- a/src/healthcheck.py
+++ b/src/healthcheck.py
@@ -113,6 +113,7 @@ def main(post_to_etlas=False):
 
     hostname = socket.gethostname()
 
+    print("Healthcheck start method definitions")
     def get_serialnum():
         return system_call("cat /proc/cpuinfo | grep Serial | cut -d ' ' -f 2")
 
@@ -162,7 +163,9 @@ def main(post_to_etlas=False):
             readersConnection[reader] = "Connected"
         else:
             readersConnection[reader] = ""
+    print("Healthcheck end method definitions")
 
+    print("Healthcheck open file block started")
     with open(file, "w+") as outfile:
         try:
             data = json.load(outfile)

--- a/src/healthcheck.py
+++ b/src/healthcheck.py
@@ -180,7 +180,7 @@ def main(post_to_etlas=False):
 
         print("In healthcheck.py: before get_host_ip")
         host_ip = str(get_host_ip())
-        if host_ip is not 'None':
+        if host_ip != 'None':
             config["controllerConfig"]["controllerIp"] = host_ip
         print("In healthcheck.py: after get_host_ip")
 

--- a/src/healthcheck.py
+++ b/src/healthcheck.py
@@ -1,5 +1,3 @@
-print("healthcheck before imports")
-
 import pigpio
 import json
 from datetime import datetime
@@ -17,6 +15,8 @@ import GPIOconfig
 from var import server_url
 from lock import config_lock
 # change_static_ip, get_default_gateway_windows
+
+print("In healthcheck.py: start")
 
 path = os.path.dirname(os.path.abspath(__file__))
 file = path+"/json/config.json"
@@ -142,9 +142,6 @@ def main(post_to_etlas=False):
         r = requests.post(url, data=json.dumps(
             body), headers=headers, verify=False)
 
-        # print(r)
-        # print(r.status_code)
-
         if r.status_code == 201 or r.status_code == 200:
             print("SUCCESS")
 
@@ -177,12 +174,15 @@ def main(post_to_etlas=False):
         current_date_time = now.strftime("%d-%m-%Y %H:%M:%S")
         readersConnection["dateAndTime"] = current_date_time
 
-        host_ip = str(get_host_ip())
         serial_num = str(get_serialnum().decode())
         mac = str(get_mac().decode())
-        config["controllerConfig"]["controllerIp"] = host_ip
         config["controllerConfig"]["controllerSerialNo"] = serial_num[:-1]
         config["controllerConfig"]["controllerMAC"] = mac[:-1]
+
+        print("In healthcheck.py: before get_host_ip")
+        host_ip = str(get_host_ip())
+        config["controllerConfig"]["controllerIp"] = host_ip
+        print("In healthcheck.py: after get_host_ip")
 
         outfile.seek(0)
         json.dump(config, outfile, indent=4)
@@ -195,3 +195,5 @@ def main(post_to_etlas=False):
                 break
             except:
                 time.sleep(0.1)
+    
+    print("In healthcheck.py: end")

--- a/src/healthcheck.py
+++ b/src/healthcheck.py
@@ -18,8 +18,6 @@ from var import server_url
 from lock import config_lock
 # change_static_ip, get_default_gateway_windows
 
-print("healthcheck after imports")
-
 path = os.path.dirname(os.path.abspath(__file__))
 file = path+"/json/config.json"
 
@@ -75,7 +73,6 @@ def system_call(command):
 
 
 def get_host_ip(hostIP=None):
-    print("Healthcheck get_host_ip started")
     if hostIP is None or hostIP == 'auto':
         hostIP = 'ip'
 
@@ -83,26 +80,17 @@ def get_host_ip(hostIP=None):
         hostIP = socket.getfqdn()
 
     elif hostIP == 'ip':
-        print("Healthcheck get_host_ip in elif block for ip")
         from socket import gaierror
-        print("Healthcheck get_host_ip before trycatch block")
         try:
-            print("Healthcheck get_host_ip in try part")
             hostIP = socket.gethostbyname(socket.getfqdn())
         except gaierror:
-            print("Healthcheck get_host_ip in catch part")
             logger.warn(
                 'gethostbyname(socket.getfqdn()) failed... trying on hostname()')
             hostIP = socket.gethostbyname(socket.gethostname())
-        print("Healthcheck get_host_ip after trycatch block")
 
-        print("Host IP is: " + str(hostIP))
-
-        print("Healthcheck get_host_ip before 127 block")
         if hostIP.startswith("127."):
             s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
             # doesn't have to be reachable
-            print("Healthcheck get_host_ip before while loop")
             while True:
                 try:
                     s.connect(('10.255.255.255', 1))
@@ -110,27 +98,19 @@ def get_host_ip(hostIP=None):
                     break
                 except:
                     time.sleep(0.1)
-            print("Healthcheck get_host_ip after while loop")
-        print("Healthcheck get_host_ip after 127 block")
 
-        print("Host IP is: " + str(hostIP))
-
-        print("Healthcheck get_host_ip before 169.264 block")
         if str(hostIP).startswith('169.254') and (not check_ip_static()):  # apipa, use static ip
             change_static_ip(
                 '192.168.1.230', get_default_gateway_windows(), '8.8.8.8')
             return get_host_ip('ip')
-        print("Healthcheck get_host_ip after 169.264 block")
 
     return str(hostIP)
 
 
 def main(post_to_etlas=False):
-    print("Healthcheck started")
 
     hostname = socket.gethostname()
 
-    print("Healthcheck start method definitions")
     def get_serialnum():
         return system_call("cat /proc/cpuinfo | grep Serial | cut -d ' ' -f 2")
 
@@ -180,49 +160,33 @@ def main(post_to_etlas=False):
             readersConnection[reader] = "Connected"
         else:
             readersConnection[reader] = ""
-    print("Healthcheck end method definitions")
 
-    print("Healthcheck open file block started")
     with open(file, "w+") as outfile:
-        print("Healthcheck before json load try catch block")
         try:
             data = json.load(outfile)
         except:
             data = []
-        print("Healthcheck after json load try catch block")
 
-        print("Healthcheck before test_for_connection calls")
         readersConnection = config["controllerConfig"]["readersConnection"]
         test_for_connection(E1_IN_D0, E1_IN_D1, "E1_IN")
         test_for_connection(E2_IN_D0, E2_IN_D1, "E2_IN")
         test_for_connection(E1_OUT_D0, E1_OUT_D1, "E1_OUT")
         test_for_connection(E2_OUT_D0, E2_OUT_D1, "E2_OUT")
-        print("Healthcheck after test_for_connection calls")
 
-        print("Healthcheck before datetime update")
         now = datetime.now()
         current_date_time = now.strftime("%d-%m-%Y %H:%M:%S")
         readersConnection["dateAndTime"] = current_date_time
-        print("Healthcheck after datetime update")
 
-        print("Healthcheck before host information update")
-        print("Healthcheck before get_host_ip call")
         host_ip = str(get_host_ip())
-        print("Healthcheck after get_host_ip call")
         serial_num = str(get_serialnum().decode())
         mac = str(get_mac().decode())
         config["controllerConfig"]["controllerIp"] = host_ip
         config["controllerConfig"]["controllerSerialNo"] = serial_num[:-1]
         config["controllerConfig"]["controllerMAC"] = mac[:-1]
-        print("Healthcheck after host information update")
 
-        print("Healthcheck before config outfile dump")
         outfile.seek(0)
         json.dump(config, outfile, indent=4)
         outfile.close()
-        print("Healthcheck after config outfile dump")
-
-    print("Healthcheck open file block completed")
 
     if post_to_etlas:
         while True:
@@ -231,5 +195,3 @@ def main(post_to_etlas=False):
                 break
             except:
                 time.sleep(0.1)
-    
-    print("Healthcheck completed")

--- a/src/healthcheck.py
+++ b/src/healthcheck.py
@@ -180,7 +180,7 @@ def main(post_to_etlas=False):
 
         print("In healthcheck.py: before get_host_ip")
         host_ip = str(get_host_ip())
-        if host_ip is not None:
+        if host_ip is not 'None':
             config["controllerConfig"]["controllerIp"] = host_ip
         print("In healthcheck.py: after get_host_ip")
 

--- a/src/healthcheck.py
+++ b/src/healthcheck.py
@@ -13,6 +13,7 @@ from changeStatic import *
 import GPIOconfig
 from var import server_url
 from lock import config_lock
+from executor import thread_pool_executor
 
 print("In healthcheck.py: start")
 
@@ -104,6 +105,35 @@ def get_host_ip(hostIP=None):
             return get_host_ip('ip')
 
     return str(hostIP)
+
+
+def threaded_get_host_ip():
+    print("In healthcheck.py: starting threaded_get_host_ip")
+
+    configFilePath = file
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    hostIP = None
+
+    while True:
+        try:
+            s.connect(('10.255.255.255', 1))
+            hostIP = s.getsockname()[0]
+            break
+        except:
+            time.sleep(10)
+            print("In healthcheck.py: Failed to get host IP, retrying...")
+    
+    with config_lock:
+        fileconfig = open(configFilePath)
+
+        json_data = json.load(fileconfig)
+        json_data["controllerConfig"]["controllerIp"] = hostIP
+        fileconfig.seek(0)
+        json.dump(json_data, fileconfig, indent=4)
+
+        fileconfig.close()
+    
+    print("In healthcheck.py: finished threaded_get_host_ip. The host IP written is:", hostIP)
 
 
 def main(post_to_etlas=False):

--- a/src/healthcheck.py
+++ b/src/healthcheck.py
@@ -106,6 +106,7 @@ def get_host_ip(hostIP=None):
 
 
 def main(post_to_etlas=False):
+    print("Healthcheck started")
 
     hostname = socket.gethostname()
 
@@ -186,6 +187,8 @@ def main(post_to_etlas=False):
         json.dump(config, outfile, indent=4)
         outfile.close()
 
+    print("Healthcheck open file block completed")
+
     if post_to_etlas:
         while True:
             try:
@@ -193,3 +196,5 @@ def main(post_to_etlas=False):
                 break
             except:
                 time.sleep(0.1)
+    
+    print("Healthcheck completed")

--- a/src/healthcheck.py
+++ b/src/healthcheck.py
@@ -4,7 +4,6 @@ from datetime import datetime
 # Python Program to Get IP Address and send to server 250
 import socket
 import subprocess
-# import psutil
 import os
 import json
 import requests
@@ -14,7 +13,6 @@ from changeStatic import *
 import GPIOconfig
 from var import server_url
 from lock import config_lock
-# change_static_ip, get_default_gateway_windows
 
 print("In healthcheck.py: start")
 
@@ -78,19 +76,16 @@ def get_host_ip(hostIP=None):
 
     if hostIP == 'dns':
         hostIP = socket.getfqdn()
-
     elif hostIP == 'ip':
-        from socket import gaierror
         try:
             hostIP = socket.gethostbyname(socket.getfqdn())
-        except gaierror:
-            logger.warn(
-                'gethostbyname(socket.getfqdn()) failed... trying on hostname()')
+        except socket.gaierror:
             hostIP = socket.gethostbyname(socket.gethostname())
 
         if hostIP.startswith("127."):
             s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-            # doesn't have to be reachable
+            timeoutCount = 0
+
             while True:
                 try:
                     s.connect(('10.255.255.255', 1))
@@ -98,6 +93,10 @@ def get_host_ip(hostIP=None):
                     break
                 except:
                     time.sleep(0.1)
+                    timeoutCount += 1
+                    if timeoutCount > 100: # 10 seconds before timeout
+                        print("Timeout while trying to get host IP")
+                        return None
 
         if str(hostIP).startswith('169.254') and (not check_ip_static()):  # apipa, use static ip
             change_static_ip(
@@ -181,7 +180,8 @@ def main(post_to_etlas=False):
 
         print("In healthcheck.py: before get_host_ip")
         host_ip = str(get_host_ip())
-        config["controllerConfig"]["controllerIp"] = host_ip
+        if host_ip is not None:
+            config["controllerConfig"]["controllerIp"] = host_ip
         print("In healthcheck.py: after get_host_ip")
 
         outfile.seek(0)

--- a/src/healthcheck.py
+++ b/src/healthcheck.py
@@ -90,7 +90,7 @@ def threaded_get_host_ip():
     print("In healthcheck.py: threaded_get_host_ip before config_lock")
     with config_lock:
         print("In healthcheck.py: threaded_get_host_ip inside config_lock")
-        fileconfig = open(configFilePath)
+        fileconfig = open(configFilePath, "r+")
         print("In healthcheck.py: threaded_get_host_ip opened config file")
 
         json_data = json.load(fileconfig)

--- a/src/healthcheck.py
+++ b/src/healthcheck.py
@@ -75,6 +75,7 @@ def system_call(command):
 
 
 def get_host_ip(hostIP=None):
+    print("Healthcheck get_host_ip started")
     if hostIP is None or hostIP == 'auto':
         hostIP = 'ip'
 
@@ -82,13 +83,18 @@ def get_host_ip(hostIP=None):
         hostIP = socket.getfqdn()
 
     elif hostIP == 'ip':
+        print("Healthcheck get_host_ip in elif block for ip")
         from socket import gaierror
+        print("Healthcheck get_host_ip before trycatch block")
         try:
             hostIP = socket.gethostbyname(socket.getfqdn())
         except gaierror:
             logger.warn(
                 'gethostbyname(socket.getfqdn()) failed... trying on hostname()')
             hostIP = socket.gethostbyname(socket.gethostname())
+        print("Healthcheck get_host_ip after trycatch block")
+
+        print("Healthcheck get_host_ip before 127 block")
         if hostIP.startswith("127."):
             s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
             # doesn't have to be reachable
@@ -99,11 +105,14 @@ def get_host_ip(hostIP=None):
                     break
                 except:
                     time.sleep(0.1)
+        print("Healthcheck get_host_ip after 127 block")
 
+        print("Healthcheck get_host_ip before 169.264 block")
         if str(hostIP).startswith('169.254') and (not check_ip_static()):  # apipa, use static ip
             change_static_ip(
                 '192.168.1.230', get_default_gateway_windows(), '8.8.8.8')
             return get_host_ip('ip')
+        print("Healthcheck get_host_ip after 169.264 block")
 
     return str(hostIP)
 

--- a/src/healthcheck.py
+++ b/src/healthcheck.py
@@ -1,3 +1,4 @@
+print("healthcheck before imports")
 
 import pigpio
 import json
@@ -16,6 +17,8 @@ import GPIOconfig
 from var import server_url
 from lock import config_lock
 # change_static_ip, get_default_gateway_windows
+
+print("healthcheck after imports")
 
 path = os.path.dirname(os.path.abspath(__file__))
 file = path+"/json/config.json"

--- a/src/healthcheck.py
+++ b/src/healthcheck.py
@@ -71,42 +71,6 @@ def system_call(command):
     return p.stdout.read()
 
 
-def get_host_ip(hostIP=None):
-    if hostIP is None or hostIP == 'auto':
-        hostIP = 'ip'
-
-    if hostIP == 'dns':
-        hostIP = socket.getfqdn()
-    elif hostIP == 'ip':
-        try:
-            hostIP = socket.gethostbyname(socket.getfqdn())
-        except socket.gaierror:
-            hostIP = socket.gethostbyname(socket.gethostname())
-
-        if hostIP.startswith("127."):
-            s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-            timeoutCount = 0
-
-            while True:
-                try:
-                    s.connect(('10.255.255.255', 1))
-                    hostIP = s.getsockname()[0]
-                    break
-                except:
-                    time.sleep(0.1)
-                    timeoutCount += 1
-                    if timeoutCount > 100: # 10 seconds before timeout
-                        print("Timeout while trying to get host IP")
-                        return None
-
-        if str(hostIP).startswith('169.254') and (not check_ip_static()):  # apipa, use static ip
-            change_static_ip(
-                '192.168.1.230', get_default_gateway_windows(), '8.8.8.8')
-            return get_host_ip('ip')
-
-    return str(hostIP)
-
-
 def threaded_get_host_ip():
     print("In healthcheck.py: starting threaded_get_host_ip")
 
@@ -134,6 +98,43 @@ def threaded_get_host_ip():
         fileconfig.close()
     
     print("In healthcheck.py: finished threaded_get_host_ip. The host IP written is:", hostIP)
+
+
+def get_host_ip(hostIP=None):
+    if hostIP is None or hostIP == 'auto':
+        hostIP = 'ip'
+
+    if hostIP == 'dns':
+        hostIP = socket.getfqdn()
+    elif hostIP == 'ip':
+        try:
+            hostIP = socket.gethostbyname(socket.getfqdn())
+        except socket.gaierror:
+            hostIP = socket.gethostbyname(socket.gethostname())
+
+        if hostIP.startswith("127."):
+            s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+            timeoutCount = 0
+
+            while True:
+                try:
+                    s.connect(('10.255.255.255', 1))
+                    hostIP = s.getsockname()[0]
+                    break
+                except:
+                    time.sleep(0.1)
+                    timeoutCount += 1
+                    if timeoutCount > 100: # 10 seconds before timeout
+                        print("Timeout while trying to get host IP")
+                        thread_pool_executor.submit(threaded_get_host_ip)
+                        return None
+
+        if str(hostIP).startswith('169.254') and (not check_ip_static()):  # apipa, use static ip
+            change_static_ip(
+                '192.168.1.230', get_default_gateway_windows(), '8.8.8.8')
+            return get_host_ip('ip')
+
+    return str(hostIP)
 
 
 def main(post_to_etlas=False):

--- a/src/healthcheck.py
+++ b/src/healthcheck.py
@@ -70,6 +70,10 @@ def system_call(command):
 
 
 def threaded_get_host_ip():
+    '''
+    This function runs in a separate thread to periodically check and update the host IP
+    in the config.json file.
+    '''
     print("In healthcheck.py: Starting threaded_get_host_ip on new thread")
 
     configFilePath = file
@@ -124,7 +128,7 @@ def get_host_ip(hostIP=None):
                     timeoutCount += 1
                     if timeoutCount > 100: # 10 seconds before timeout
                         print("In healhcheck.py: Timeout while trying to get host IP")
-                        thread_pool_executor.submit(threaded_get_host_ip)
+                        thread_pool_executor.submit(threaded_get_host_ip) ## Start new thread and continue with main process
                         return None
 
         if str(hostIP).startswith('169.254') and (not check_ip_static()):  # apipa, use static ip
@@ -208,7 +212,7 @@ def main(post_to_etlas=False):
         config["controllerConfig"]["controllerMAC"] = mac[:-1]
 
         host_ip = str(get_host_ip())
-        if host_ip != 'None':
+        if host_ip != 'None': ## Only write if a valid IP was found
             config["controllerConfig"]["controllerIp"] = host_ip
 
         outfile.seek(0)

--- a/src/healthcheck.py
+++ b/src/healthcheck.py
@@ -15,8 +15,6 @@ from var import server_url
 from lock import config_lock
 from executor import thread_pool_executor
 
-print("In healthcheck.py: start")
-
 path = os.path.dirname(os.path.abspath(__file__))
 file = path+"/json/config.json"
 
@@ -72,7 +70,7 @@ def system_call(command):
 
 
 def threaded_get_host_ip():
-    print("In healthcheck.py: starting threaded_get_host_ip")
+    print("In healthcheck.py: Starting threaded_get_host_ip on new thread")
 
     configFilePath = file
     s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
@@ -87,25 +85,17 @@ def threaded_get_host_ip():
             time.sleep(10)
             print("In healthcheck.py: Failed to get host IP, retrying...")
     
-    print("In healthcheck.py: threaded_get_host_ip before config_lock")
     with config_lock:
-        print("In healthcheck.py: threaded_get_host_ip inside config_lock")
         fileconfig = open(configFilePath, "r+")
-        print("In healthcheck.py: threaded_get_host_ip opened config file")
 
         json_data = json.load(fileconfig)
-        print("In healthcheck.py: threaded_get_host_ip loaded json data")
         json_data["controllerConfig"]["controllerIp"] = hostIP
-        print("In healthcheck.py: threaded_get_host_ip set controllerIp to", hostIP)
         fileconfig.seek(0)
         json.dump(json_data, fileconfig, indent=4)
-        print("In healthcheck.py: threaded_get_host_ip dumped json data")
 
         fileconfig.close()
-        print("In healthcheck.py: threaded_get_host_ip closed config file")
-    print("In healthcheck.py: threaded_get_host_ip after config_lock")
     
-    print("In healthcheck.py: finished threaded_get_host_ip. The host IP written is:", hostIP)
+    print("In healthcheck.py: Finished threaded_get_host_ip. The host IP written is to config.json is:", hostIP)
 
 
 def get_host_ip(hostIP=None):
@@ -133,7 +123,7 @@ def get_host_ip(hostIP=None):
                     time.sleep(0.1)
                     timeoutCount += 1
                     if timeoutCount > 100: # 10 seconds before timeout
-                        print("Timeout while trying to get host IP")
+                        print("In healhcheck.py: Timeout while trying to get host IP")
                         thread_pool_executor.submit(threaded_get_host_ip)
                         return None
 
@@ -217,11 +207,9 @@ def main(post_to_etlas=False):
         config["controllerConfig"]["controllerSerialNo"] = serial_num[:-1]
         config["controllerConfig"]["controllerMAC"] = mac[:-1]
 
-        print("In healthcheck.py: before get_host_ip")
         host_ip = str(get_host_ip())
         if host_ip != 'None':
             config["controllerConfig"]["controllerIp"] = host_ip
-        print("In healthcheck.py: after get_host_ip")
 
         outfile.seek(0)
         json.dump(config, outfile, indent=4)
@@ -234,5 +222,3 @@ def main(post_to_etlas=False):
                 break
             except:
                 time.sleep(0.1)
-    
-    print("In healthcheck.py: end")

--- a/src/healthcheck.py
+++ b/src/healthcheck.py
@@ -189,13 +189,15 @@ def main(post_to_etlas=False):
         print("Healthcheck after datetime update")
 
         print("Healthcheck before host information update")
+        print("Healthcheck before get_host_ip call")
         host_ip = str(get_host_ip())
+        print("Healthcheck after get_host_ip call")
         serial_num = str(get_serialnum().decode())
         mac = str(get_mac().decode())
         config["controllerConfig"]["controllerIp"] = host_ip
         config["controllerConfig"]["controllerSerialNo"] = serial_num[:-1]
         config["controllerConfig"]["controllerMAC"] = mac[:-1]
-        print("Healthcheck before host information update")
+        print("Healthcheck after host information update")
 
         print("Healthcheck before config outfile dump")
         outfile.seek(0)

--- a/src/healthcheck.py
+++ b/src/healthcheck.py
@@ -87,17 +87,22 @@ def get_host_ip(hostIP=None):
         from socket import gaierror
         print("Healthcheck get_host_ip before trycatch block")
         try:
+            print("Healthcheck get_host_ip in try part")
             hostIP = socket.gethostbyname(socket.getfqdn())
         except gaierror:
+            print("Healthcheck get_host_ip in catch part")
             logger.warn(
                 'gethostbyname(socket.getfqdn()) failed... trying on hostname()')
             hostIP = socket.gethostbyname(socket.gethostname())
         print("Healthcheck get_host_ip after trycatch block")
 
+        print("Host IP is: " + str(hostIP))
+
         print("Healthcheck get_host_ip before 127 block")
         if hostIP.startswith("127."):
             s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
             # doesn't have to be reachable
+            print("Healthcheck get_host_ip before while loop")
             while True:
                 try:
                     s.connect(('10.255.255.255', 1))
@@ -105,7 +110,10 @@ def get_host_ip(hostIP=None):
                     break
                 except:
                     time.sleep(0.1)
+            print("Healthcheck get_host_ip after while loop")
         print("Healthcheck get_host_ip after 127 block")
+
+        print("Host IP is: " + str(hostIP))
 
         print("Healthcheck get_host_ip before 169.264 block")
         if str(hostIP).startswith('169.254') and (not check_ip_static()):  # apipa, use static ip

--- a/src/healthcheck.py
+++ b/src/healthcheck.py
@@ -167,31 +167,41 @@ def main(post_to_etlas=False):
 
     print("Healthcheck open file block started")
     with open(file, "w+") as outfile:
+        print("Healthcheck before json load try catch block")
         try:
             data = json.load(outfile)
         except:
             data = []
+        print("Healthcheck after json load try catch block")
 
+        print("Healthcheck before test_for_connection calls")
         readersConnection = config["controllerConfig"]["readersConnection"]
         test_for_connection(E1_IN_D0, E1_IN_D1, "E1_IN")
         test_for_connection(E2_IN_D0, E2_IN_D1, "E2_IN")
         test_for_connection(E1_OUT_D0, E1_OUT_D1, "E1_OUT")
         test_for_connection(E2_OUT_D0, E2_OUT_D1, "E2_OUT")
+        print("Healthcheck after test_for_connection calls")
 
+        print("Healthcheck before datetime update")
         now = datetime.now()
         current_date_time = now.strftime("%d-%m-%Y %H:%M:%S")
         readersConnection["dateAndTime"] = current_date_time
+        print("Healthcheck after datetime update")
 
+        print("Healthcheck before host information update")
         host_ip = str(get_host_ip())
         serial_num = str(get_serialnum().decode())
         mac = str(get_mac().decode())
         config["controllerConfig"]["controllerIp"] = host_ip
         config["controllerConfig"]["controllerSerialNo"] = serial_num[:-1]
         config["controllerConfig"]["controllerMAC"] = mac[:-1]
+        print("Healthcheck before host information update")
 
+        print("Healthcheck before config outfile dump")
         outfile.seek(0)
         json.dump(config, outfile, indent=4)
         outfile.close()
+        print("Healthcheck after config outfile dump")
 
     print("Healthcheck open file block completed")
 

--- a/src/healthcheck.py
+++ b/src/healthcheck.py
@@ -87,15 +87,23 @@ def threaded_get_host_ip():
             time.sleep(10)
             print("In healthcheck.py: Failed to get host IP, retrying...")
     
+    print("In healthcheck.py: threaded_get_host_ip before config_lock")
     with config_lock:
+        print("In healthcheck.py: threaded_get_host_ip inside config_lock")
         fileconfig = open(configFilePath)
+        print("In healthcheck.py: threaded_get_host_ip opened config file")
 
         json_data = json.load(fileconfig)
+        print("In healthcheck.py: threaded_get_host_ip loaded json data")
         json_data["controllerConfig"]["controllerIp"] = hostIP
+        print("In healthcheck.py: threaded_get_host_ip set controllerIp to", hostIP)
         fileconfig.seek(0)
         json.dump(json_data, fileconfig, indent=4)
+        print("In healthcheck.py: threaded_get_host_ip dumped json data")
 
         fileconfig.close()
+        print("In healthcheck.py: threaded_get_host_ip closed config file")
+    print("In healthcheck.py: threaded_get_host_ip after config_lock")
     
     print("In healthcheck.py: finished threaded_get_host_ip. The host IP written is:", hostIP)
 


### PR DESCRIPTION
Implemented a bugfix for the network dependency issue that causes the configuration file to be empty, which is suspected to cause the normal functions of the physical hardware to not work properly.

Situations where the bug could happen is when both network and power to the Pi goes down, but power is restored first before the network. In the timeframe before the network comes back, the config file is empty due to `healthcheck.py` getting stuck in a loop, which likely caused the issue of the hardware not working

Fix is implemented by having the IP acquisition loop timeout after 10 seconds and continue with normal operations (meaning the config file is written back to and not empty anymore), while having the process shoot off a separate thread that checks for network connectivity every 10 seconds, and updates the config file once a valid IP address is found.

In the case where network is down, the IP address in the config file will be retained to what it was originally.